### PR TITLE
Add parameterized supertype support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Changed
 - Dependencies:
   - Upgrade Kotlin to `1.5.10`
-  - Upgrade Hilt to `2.36`
+  - Upgrade Hilt to `2.37`
 
 ## [1.1.1]
 ### Changed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.10")
         classpath("org.jetbrains.kotlin:kotlin-serialization:1.5.10")
         classpath("com.android.tools.build:gradle:4.2.1")
-        classpath("com.google.dagger:hilt-android-gradle-plugin:2.36")
+        classpath("com.google.dagger:hilt-android-gradle-plugin:2.37")
         classpath("de.mannodermaus.gradle.plugins:android-junit5:1.7.1.1")
     }
 }

--- a/examples/generated-modules/build.gradle.kts
+++ b/examples/generated-modules/build.gradle.kts
@@ -46,8 +46,8 @@ kapt {
 }
 
 dependencies {
-    implementation("com.google.dagger:hilt-android:2.36")
-    kapt("com.google.dagger:hilt-android-compiler:2.36")
+    implementation("com.google.dagger:hilt-android:2.37")
+    kapt("com.google.dagger:hilt-android-compiler:2.37")
 
     implementation(project(":hilt:extensions"))
     kapt(project(":hilt:processor"))
@@ -77,8 +77,8 @@ dependencies {
 
     implementation("com.squareup.picasso:picasso:2.8")
 
-    androidTestImplementation("com.google.dagger:hilt-android-testing:2.36")
-    kaptAndroidTest("com.google.dagger:hilt-android-compiler:2.36")
+    androidTestImplementation("com.google.dagger:hilt-android-testing:2.37")
+    kaptAndroidTest("com.google.dagger:hilt-android-compiler:2.37")
 
     androidTestImplementation("io.ktor:ktor-client-mock:1.5.4")
 

--- a/hilt/annotations/build.gradle.kts
+++ b/hilt/annotations/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.google.dagger:hilt-core:2.36")
+    implementation("com.google.dagger:hilt-core:2.37")
 }
 
 tasks.withType<KotlinCompile> {

--- a/hilt/extensions/build.gradle.kts
+++ b/hilt/extensions/build.gradle.kts
@@ -33,7 +33,7 @@ android {
 dependencies {
     api(project(":hilt:annotations"))
 
-    implementation("com.google.dagger:hilt-android:2.36")
+    implementation("com.google.dagger:hilt-android:2.37")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.2")

--- a/hilt/fragment-testing/build.gradle.kts
+++ b/hilt/fragment-testing/build.gradle.kts
@@ -43,8 +43,8 @@ kapt {
 }
 
 dependencies {
-    implementation("com.google.dagger:hilt-android:2.36")
-    kapt("com.google.dagger:hilt-android-compiler:2.36")
+    implementation("com.google.dagger:hilt-android:2.37")
+    kapt("com.google.dagger:hilt-android-compiler:2.37")
 
     api("androidx.test:core:1.3.0")
 
@@ -56,8 +56,8 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-core:3.3.0")
     androidTestImplementation("com.google.android.material:material:1.3.0")
     androidTestImplementation("androidx.activity:activity-ktx:1.2.3")
-    androidTestImplementation("com.google.dagger:hilt-android-testing:2.36")
-    kaptAndroidTest("com.google.dagger:hilt-android-compiler:2.36")
+    androidTestImplementation("com.google.dagger:hilt-android-testing:2.37")
+    kaptAndroidTest("com.google.dagger:hilt-android-compiler:2.37")
 }
 
 tasks {

--- a/hilt/processor/build.gradle.kts
+++ b/hilt/processor/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     implementation(project(":hilt:annotations"))
 
     implementation("androidx.annotation:annotation:1.2.0")
-    implementation("com.google.dagger:hilt-core:2.36")
+    implementation("com.google.dagger:hilt-core:2.37")
     implementation("com.squareup:javapoet:1.13.0")
 }
 

--- a/hilt/processor/src/main/kotlin/TypeNameExtensions.kt
+++ b/hilt/processor/src/main/kotlin/TypeNameExtensions.kt
@@ -1,0 +1,13 @@
+package it.czerwinski.android.hilt.processor
+
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.ParameterizedTypeName
+import com.squareup.javapoet.TypeName
+
+fun TypeName.rawType(): ClassName {
+    return when (this) {
+        is ClassName -> this
+        is ParameterizedTypeName -> rawType
+        else -> throw IllegalArgumentException("Unsupported type $this")
+    }
+}

--- a/hilt/processor/src/main/kotlin/model/Binding.kt
+++ b/hilt/processor/src/main/kotlin/model/Binding.kt
@@ -19,15 +19,17 @@ package it.czerwinski.android.hilt.processor.model
 
 import com.squareup.javapoet.AnnotationSpec
 import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.TypeName
+import it.czerwinski.android.hilt.processor.rawType
 
 data class Binding(
     val annotatedClassName: ClassName,
-    val supertypeClassName: ClassName,
+    val supertypeClassName: TypeName,
     val componentClassName: ClassName,
     val annotations: List<AnnotationSpec>,
     val isTest: Boolean
 ) {
 
     val groupingKey: ModuleGroupingKey =
-        ModuleGroupingKey(annotatedClassName.packageName(), supertypeClassName, componentClassName, isTest)
+        ModuleGroupingKey(annotatedClassName.packageName(), supertypeClassName.rawType(), componentClassName, isTest)
 }

--- a/hilt/processor/src/main/kotlin/model/BindingBuilder.kt
+++ b/hilt/processor/src/main/kotlin/model/BindingBuilder.kt
@@ -56,7 +56,7 @@ class BindingBuilder(private val processingEnv: ProcessingEnvironment) {
 
         return Binding(
             annotatedClassName = element.className(),
-            supertypeClassName = (visitor.supertypeClassName ?: getSupertypeClassName(element)) as ClassName,
+            supertypeClassName = visitor.supertypeClassName ?: getSupertypeClassName(element),
             componentClassName = visitor.componentClassName as? ClassName ?: defaultComponentClassName,
             annotations = element.scopesAndQualifiers().map(AnnotationSpec::get),
             isTest = annotationType.simpleName.startsWith(TEST_ANNOTATION_PREFIX)

--- a/hilt/processor/src/main/kotlin/poet/BaseModulePoet.kt
+++ b/hilt/processor/src/main/kotlin/poet/BaseModulePoet.kt
@@ -24,12 +24,14 @@ import com.squareup.javapoet.TypeSpec
 import dagger.Module
 import dagger.hilt.InstallIn
 import it.czerwinski.android.hilt.processor.model.ModuleGroupingKey
+import it.czerwinski.android.hilt.processor.rawType
 import javax.lang.model.element.Modifier
 
 open class BaseModulePoet {
 
-    protected fun TypeName.toModuleNamePrefix(): String =
-        (box() as ClassName).simpleNames().joinToString(SIMPLE_NAME_SEPARATOR)
+    protected fun TypeName.toModuleNamePrefix(): String {
+        return box().rawType().simpleNames().joinToString(SIMPLE_NAME_SEPARATOR)
+    }
 
     protected fun TypeSpec.Builder.addCommonModuleSetup(
         groupingKey: ModuleGroupingKey,


### PR DESCRIPTION
Closes #122

Changes:
* `Binding.supertypeClassName` is now a `TypeName` instead of a `ClassName` to allow parameterized supertype 

Note:
* To allow support with `BoundTo` annotation, we would need to introduce something like `val typeArguments: List<KClass<*>>` in the annotation. But this is not perfect either, since it only accounts for 1 level of nesting

Example:

```kotlin
@Bound
class Foo @Inject constructor() : Converter<String, Int>

@Bound
class Bar @Inject constructor() : Converter<List<String>, List<Int>>
```

will generate:

```java
@Binds
@NonNull
Converter<List<? extends String>, List<? extends Integer>> bindBar(@NonNull Bar implementation);

@Binds
@NonNull
Converter<String, Integer> bindFoo(@NonNull Foo implementation);
```

and can be injected like this:
```kotlin
class TestInject @Inject constructor(
    val foo: Converter<String, Int>,
    val bar: Converter<List<String>, List<Int>>
)
```
